### PR TITLE
Added MIRROR arg to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
+ARG MIRROR=keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/library
 ARG DISTRO=ubuntu
 ARG DISTRO_RELEASE=xenial
-ARG FROM=${DISTRO}:${DISTRO_RELEASE}
+ARG FROM=${MIRROR}/${DISTRO}:${DISTRO_RELEASE}
 FROM ${FROM}
 
 ENV PATH=/var/lib/openstack/bin:$PATH


### PR DESCRIPTION
This patch adds the keppel url to the Dockerfile FROM
arg so that pulls go through keppel instead of upstream docker hub,
which is now painfully rate limited.