### PR TITLE
Remove Ceph support

### DIFF
--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -7,7 +7,6 @@ ARG DISTRO=ubuntu
 ARG DISTRO_RELEASE=xenial
 ARG UBUNTU_URL=http://archive.ubuntu.com/ubuntu/
 ARG CLOUD_ARCHIVE_URL=http://ubuntu-cloud.archive.canonical.com/ubuntu/
-ARG CEPH_URL=http://download.ceph.com/debian-luminous/
 ARG ALLOW_UNAUTHENTICATED=false
 ARG PIP_INDEX_URL=https://pypi.python.org/simple/
 ARG PIP_TRUSTED_HOST=pypi.python.org
@@ -24,7 +23,6 @@ RUN sed -i \
         -e "s|%%UBUNTU_URL%%|${UBUNTU_URL}|g" \
         -e "s|%%UBUNTU_RELEASE%%|${DISTRO_RELEASE}|g" \
         -e "s|%%CLOUD_ARCHIVE_URL%%|${CLOUD_ARCHIVE_URL}|g" \
-        -e "s|%%CEPH_URL%%|${CEPH_URL}|g" \
         -e "s|%%OPENSTACK_RELEASE%%|${OPENSTACK_RELEASE}|g" \
         /etc/apt/sources.list
 RUN echo "APT::Get::AllowUnauthenticated \"${ALLOW_UNAUTHENTICATED}\";" > /etc/apt/apt.conf.d/allow-unathenticated

--- a/dockerfiles/ubuntu/sources.list
+++ b/dockerfiles/ubuntu/sources.list
@@ -2,5 +2,4 @@ deb %%UBUNTU_URL%% %%UBUNTU_RELEASE%% main universe
 deb %%UBUNTU_URL%% %%UBUNTU_RELEASE%%-updates main universe
 deb %%UBUNTU_URL%% %%UBUNTU_RELEASE%%-backports main universe
 deb %%UBUNTU_URL%% %%UBUNTU_RELEASE%%-security main universe
-deb %%CEPH_URL%% %%UBUNTU_RELEASE%% main
 deb %%CLOUD_ARCHIVE_URL%% %%UBUNTU_RELEASE%%-updates/%%OPENSTACK_RELEASE%% main


### PR DESCRIPTION
We do not use Ceph and there are no Ceph packages available for Ubuntu jammy, which is required for using OpenStack Zed. Therefore, we remove the Ceph repo from the sources.list and thus make it not possible to install it anymore.