### PR TITLE
Use cloud-archive yoga updates for nova also in xena

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -96,6 +96,10 @@ fi
 $(dirname $0)/clone_project.sh
 if [[ "${EXTENSIONS}" == "no" ]]; then
     if [[ ${PROJECT} == 'nova' ]]; then
+        if [[ "${DISTRO_RELEASE}" == "focal" ]]; then
+            sed -i 's#deb http://ubuntu-cloud.archive.canonical.com/ubuntu/ focal-updates/xena main#deb http://ubuntu-cloud.archive.canonical.com/ubuntu/ focal-updates/yoga main#' /etc/apt/sources.list
+            apt-get update
+        fi
         $(dirname $0)/install_nova_console.sh
     fi
     $(dirname $0)/install_packages.sh


### PR DESCRIPTION
We test only for focal, but zed is already on jammy. And for yoga, the change isn't really a change.

At that point in the script, it will pull in only newer packages related to qemu, and psycopg2, which isn't used, so the scope of the change is quite limited.

Here the complete list:
```
librados2
librbd1
libvirt0
openvswitch-common
python3-openvswitch
openvswitch-switch
python3-psycopg2
```