### PR TITLE
Use treeless clone for project checkout

### DIFF
--- a/scripts/clone_project.sh
+++ b/scripts/clone_project.sh
@@ -2,8 +2,7 @@
 
 set -eux
 
-git clone ${PROJECT_REPO} /tmp/${PROJECT}
+git clone --filter=tree:0 ${PROJECT_REPO} /tmp/${PROJECT}
 pushd /tmp/${PROJECT}
-git fetch ${PROJECT_REPO} ${PROJECT_REF}
-git checkout FETCH_HEAD
+git checkout ${PROJECT_REF}
 popd


### PR DESCRIPTION
The openstack projects have fairly large repositories due to their long history, which makes the checkout quite slow.

A treeless clone will get the whole history, but not the changes themselves, which allows us to checkout any reference (branch or commit-hash) directly, which will then fetch the files needed

For details see:
https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/