### PR TITLE
Remove support source_repository for keppel, as we have it in the ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,5 +37,4 @@ ARG MKS_REF=master
 COPY scripts /opt/loci/scripts
 ADD bindep.txt pydep.txt $EXTRA_BINDEP $EXTRA_PYDEP /opt/loci/
 
-LABEL source_repository=${PROJECT_REPO}
 RUN /opt/loci/scripts/install.sh

--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -14,8 +14,6 @@ ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 ENV PIP_TRUSTED_HOST=${PIP_TRUSTED_HOST}
 ARG OPENSTACK_RELEASE=rocky
 
-LABEL source_repository="https://github.com/sapcc/loci"
-
 COPY sources.list /etc/apt/
 COPY cloud-archive.gpg ceph.gpg /etc/apt/trusted.gpg.d/
 RUN bash -c '[[ "$OPENSTACK_RELEASE" == "mitaka" ]] && sed -i -e /%%CLOUD_ARCHIVE_URL%%/d /etc/apt/sources.list; exit 0'


### PR DESCRIPTION
This reverts commit 75167208fba7d5b20a07a815f8f01b54bfd23f39
This reverts commit 6d26af5c6219af36da7d1850a61319682b482e61