### PR TITLE
Split out certs & Add own backport archive

### DIFF
--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -14,25 +14,20 @@ ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 ENV PIP_TRUSTED_HOST=${PIP_TRUSTED_HOST}
 ARG OPENSTACK_RELEASE=rocky
 
-COPY sources.list /etc/apt/
+COPY sources.list sources.list.d /etc/apt/
+COPY sources.list.d/* /etc/apt/sources.list.d
 COPY cloud-archive.gpg ceph.gpg /etc/apt/trusted.gpg.d/
-RUN bash -c '[[ "$OPENSTACK_RELEASE" == "mitaka" ]] && sed -i -e /%%CLOUD_ARCHIVE_URL%%/d /etc/apt/sources.list; exit 0'
-RUN sed -i \
+RUN ( [ -z "$CLOUD_ARCHIVE_URL" ] && \
+        sed -i -e /%%CLOUD_ARCHIVE_URL%%/d /etc/apt/sources.list ) && \
+        sed -i \
         -e "s|%%UBUNTU_URL%%|${UBUNTU_URL}|g" \
         -e "s|%%UBUNTU_RELEASE%%|${DISTRO_RELEASE}|g" \
         -e "s|%%CLOUD_ARCHIVE_URL%%|${CLOUD_ARCHIVE_URL}|g" \
         -e "s|%%OPENSTACK_RELEASE%%|${OPENSTACK_RELEASE}|g" \
-        /etc/apt/sources.list
-RUN echo "APT::Get::AllowUnauthenticated \"${ALLOW_UNAUTHENTICATED}\";" > /etc/apt/apt.conf.d/allow-unathenticated
+        /etc/apt/sources.list && \
+        ( [ ! -d /etc/apt/sources.list.d ] || sed -i -e "s|%%UBUNTU_RELEASE%%|${DISTRO_RELEASE}|g" /etc/apt/sources.list.d/* )
 
-# add SAP certificates
-ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
-COPY certificates/* /usr/local/share/ca-certificates/
-
-RUN echo 'precedence ::ffff:0:0/96  100' >> /etc/gai.conf && \
-    apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends ca-certificates && \
-    update-ca-certificates && \
-    apt-get purge -y --auto-remove ca-certificates && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /root/.cache
+RUN echo "APT::Get::AllowUnauthenticated \"${ALLOW_UNAUTHENTICATED}\";\n\
+Acquire::AllowInsecureRepositories \"${ALLOW_UNAUTHENTICATED}\";\n\
+Acquire::AllowDowngradeToInsecureRepositories \"${ALLOW_UNAUTHENTICATED}\";" \
+    >> /etc/apt/apt.conf.d/allow-unathenticated

--- a/dockerfiles/ubuntu/Dockerfile.sapcerts
+++ b/dockerfiles/ubuntu/Dockerfile.sapcerts
@@ -1,0 +1,15 @@
+ARG DISTRO=ubuntu
+ARG DISTRO_RELEASE=xenial
+ARG FROM=${DISTRO}:${DISTRO_RELEASE}
+FROM ${FROM}
+
+# add SAP certificates
+ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+COPY certificates/* /usr/local/share/ca-certificates/
+
+RUN echo 'precedence ::ffff:0:0/96  100' >> /etc/gai.conf && \
+    apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    update-ca-certificates && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /root/.cache

--- a/dockerfiles/ubuntu/sources.list.d/backports.list
+++ b/dockerfiles/ubuntu/sources.list.d/backports.list
@@ -1,0 +1,1 @@
+deb [trusted=yes] https://repo.eu-de-1.cloud.sap/loci-deb-backports/%%UBUNTU_RELEASE%% backports/


### PR DESCRIPTION
Otherwise we have a bit of a chicken and egg problem when wanting to use a sap-internal repository.

Now we build just the Dockerfile.sapcerts and
based on top of that we build Dockerfile.

Change-Id: I9f4ba74d7fc230d0e7b97c76982e096a8efe478a