### PR TITLE
Configure Sentry_SDK

### DIFF
--- a/scripts/data/ccsentry.py
+++ b/scripts/data/ccsentry.py
@@ -1,0 +1,48 @@
+import os
+import sys
+
+
+def enable_sentry_sdk():
+
+    try:
+        import sentry_sdk
+        from sentry_sdk.integrations.logging import LoggingIntegration
+
+        dsn = os.getenv('SENTRY_DSN')
+
+        if not dsn:
+            print("SENTRY_DSN not set", file=sys.stderr)
+            return
+
+        # the current DSN has requests+https as schema and an option to
+        # skip ssl verification. Need to remove both for sentry_sdk
+        if 'requests' in dsn:
+            _, dsn = dsn.split('https://', 1)
+            dsn = f"https://{dsn}"
+        if '?' in dsn:
+            dsn, _ = dsn.rsplit('?', 1)
+
+        sentry_sdk.init(
+            integrations=[LoggingIntegration(level=None, event_level=None), ],
+            default_integrations=False,
+            dsn=dsn
+        )
+        print("sentry_sdk initialized.", file=sys.stderr)
+
+    except ImportError:
+        # do not fail if sentry_sdk is not (yet) installed in this image,
+        # e.g. when using image-patcher.
+        pass
+    except ValueError as v:
+        print(f"unable to configure sentry: {v}", file=sys.stderr)
+
+
+def check_for_sentry():
+    use_sdk = os.getenv('SENTRY_USE_SDK')
+    if not use_sdk:
+        return
+    if use_sdk.lower() in ('true', 'yes', '1', 'on', 'enabled'):
+        enable_sentry_sdk()
+
+
+check_for_sentry()

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -116,4 +116,5 @@ else
     fi
 fi
 $(dirname $0)/setup_pyroscope.py
+$(dirname $0)/setup_sentry_sdk.py
 $(dirname $0)/cleanup.sh

--- a/scripts/setup_sentry_sdk.py
+++ b/scripts/setup_sentry_sdk.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+import os
+import sys
+
+site_packages_path = next(p for p in sys.path
+         if p and p.endswith('site-packages'))
+
+pth_path = os.path.join(site_packages_path, "ccsentry.pth")
+py_path = os.path.join(site_packages_path, "ccsentry.py")
+
+pth_script = """\
+import ccsentry
+"""
+
+ccsentry = """\
+import os
+import sys
+
+
+def enable_sentry_sdk():
+
+    try:
+        import sentry_sdk
+        from sentry_sdk.integrations.logging import LoggingIntegration
+
+        dsn = os.getenv('SENTRY_DSN')
+
+        if not dsn:
+            print("SENTRY_DSN not set", file=sys.stderr)
+            return
+
+        # the current DSN has requests+https as schema and an option to
+        # skip ssl verification. Need to remove both for sentry_sdk
+        if 'requests' in dsn:
+            _, dsn = dsn.split('https://', 1)
+            dsn = f"https://{dsn}"
+        if '?' in dsn:
+            dsn, _ = dsn.rsplit('?', 1)
+
+        sentry_sdk.init(
+            integrations=[LoggingIntegration(level=None, event_level=None),],
+            default_integrations=False,
+            dsn=dsn
+        )
+        print("sentry_sdk initialized.", file=sys.stderr)
+
+    except ImportError:
+        # do not fail if sentry_sdk is not (yet) installed in this image,
+        # e.g. when using image-patcher.
+        pass
+    except ValueError as v:
+        print(f"unable to configure sentry: {v}", file=sys.stderr)
+
+
+def check_for_sentry():
+    use_sdk = os.getenv('SENTRY_USE_SDK')
+    if not use_sdk:
+        return
+    if use_sdk.lower() in ('true', 'yes', '1', 'on', 'enabled'):
+        enable_sentry_sdk()
+
+
+check_for_sentry()
+"""
+
+def write_script(path, script):
+    if not os.path.exists(path):
+        with open(path, "w") as sc:
+            print("Writing to " + path)
+            sc.write(script)
+            sc.flush()
+
+write_script(pth_path, pth_script)
+write_script(py_path, ccsentry)

--- a/scripts/setup_sentry_sdk.py
+++ b/scripts/setup_sentry_sdk.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 import os
 import sys
+import pathlib
+import shutil
 
 site_packages_path = next(p for p in sys.path
-         if p and p.endswith('site-packages'))
+                          if p and p.endswith('site-packages'))
 
 pth_path = os.path.join(site_packages_path, "ccsentry.pth")
 py_path = os.path.join(site_packages_path, "ccsentry.py")
@@ -12,56 +14,6 @@ pth_script = """\
 import ccsentry
 """
 
-ccsentry = """\
-import os
-import sys
-
-
-def enable_sentry_sdk():
-
-    try:
-        import sentry_sdk
-        from sentry_sdk.integrations.logging import LoggingIntegration
-
-        dsn = os.getenv('SENTRY_DSN')
-
-        if not dsn:
-            print("SENTRY_DSN not set", file=sys.stderr)
-            return
-
-        # the current DSN has requests+https as schema and an option to
-        # skip ssl verification. Need to remove both for sentry_sdk
-        if 'requests' in dsn:
-            _, dsn = dsn.split('https://', 1)
-            dsn = f"https://{dsn}"
-        if '?' in dsn:
-            dsn, _ = dsn.rsplit('?', 1)
-
-        sentry_sdk.init(
-            integrations=[LoggingIntegration(level=None, event_level=None),],
-            default_integrations=False,
-            dsn=dsn
-        )
-        print("sentry_sdk initialized.", file=sys.stderr)
-
-    except ImportError:
-        # do not fail if sentry_sdk is not (yet) installed in this image,
-        # e.g. when using image-patcher.
-        pass
-    except ValueError as v:
-        print(f"unable to configure sentry: {v}", file=sys.stderr)
-
-
-def check_for_sentry():
-    use_sdk = os.getenv('SENTRY_USE_SDK')
-    if not use_sdk:
-        return
-    if use_sdk.lower() in ('true', 'yes', '1', 'on', 'enabled'):
-        enable_sentry_sdk()
-
-
-check_for_sentry()
-"""
 
 def write_script(path, script):
     if not os.path.exists(path):
@@ -70,5 +22,13 @@ def write_script(path, script):
             sc.write(script)
             sc.flush()
 
+
+def copy_data(path, srcname):
+    our_dir = pathlib.Path(__file__).parent.resolve()
+    src = our_dir.joinpath('data').joinpath(srcname)
+    print(f"copying {srcname} to {path}")
+    shutil.copyfile(src, path)
+
+
+copy_data(py_path, 'ccsentry.py')
 write_script(pth_path, pth_script)
-write_script(py_path, ccsentry)


### PR DESCRIPTION
Configure Sentry_SDK

The sentry raven library is long deprecated. The python sentry SDK replaces this library.
To get the same behaviour as with raven (only enable the logging with selected loggers via the Handlers), one has to initialise the SDK but manually configure the Logging integration and set the default levels to None.

 Avoiding the sentry configuration in each SAPCC upstream based project (e.g. Neutron or Nova) and furthermore
 in each driver, this has is part of the loci build process. During the build a .pth and .py file will be placed in the
 site_package path. Within this path, an executable line in a .pth file is run at every Python startup.
 In our case, a script configuring sentry if the env variable SENTRY_USE_SDK is
 set. As requirements sentry-sdk must be installed.
