### PR TITLE
Switch spice-html5 git repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ ARG GID=42424
 
 ARG NOVNC_REPO=https://github.com/novnc/novnc
 ARG NOVNC_REF=v1.0.0
-ARG SPICE_REPO=https://gitlab.freedesktop.org/spice/spice-html5.git
+ARG SPICE_REPO=git://anongit.freedesktop.org/spice/spice-html5
 ARG SPICE_REF=spice-html5-0.1.6
 ARG MKS_REPO=https://github.com/rgerganov/noVNC.git
 ARG MKS_REF=master


### PR DESCRIPTION
gitlab.freedesktop.org is rebuilt on another hoster for 2 weeks, but we need to be able to create Nova images, so we use their mirror.

Change-Id: I5304e1c625e0004e7871a0a82b43221bcf79eac6