### PR TITLE
Add support for Ubuntu Noble to install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,11 +20,7 @@ if [[ "${PYTHON3}" == "no" ]]; then
     python3=""
     python_version=2
 else
-    if [[ "${distro_version}" == "noble" ]]; then
-        dpkg_python_packages=("python3" "python3-virtualenv" "python3-setuptools")
-    else
-        dpkg_python_packages=("python3" "python3-virtualenv" "python3-distutils")
-    fi
+    dpkg_python_packages=("python3" "python3-virtualenv")
     rpm_python_packages=("python3" "python3-virtualenv")
     python3="python3"
     python_version=3
@@ -37,6 +33,9 @@ fi
 case ${distro} in
     debian|ubuntu)
         apt-get update
+        if [[ ! -z "$(apt-cache search ^python3-distutils$)" ]] && [[ "${PYTHON3}" != "no" ]]; then
+            dpkg_python_packages+=("python3-distutils")
+        fi
         apt-get upgrade -y
         apt-get install -y --no-install-recommends \
             git \

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,7 +20,11 @@ if [[ "${PYTHON3}" == "no" ]]; then
     python3=""
     python_version=2
 else
-    dpkg_python_packages=("python3" "python3-virtualenv" "python3-distutils")
+    if [[ "${distro_version}" == "noble" ]]; then
+        dpkg_python_packages=("python3" "python3-virtualenv" "python3-setuptools")
+    else
+        dpkg_python_packages=("python3" "python3-virtualenv" "python3-distutils")
+    fi
     rpm_python_packages=("python3" "python3-virtualenv")
     python3="python3"
     python_version=3


### PR DESCRIPTION
This PR adds support for building Ubuntu Noble image with install.sh script. Fixed error:
```
...
#8 116.8 + apt-get install -y --no-install-recommends git ca-certificates netbase lsb-release patch sudo curl python3 python3-virtualenv python3-distutils
#8 116.8 Reading package lists...
#8 118.2 Building dependency tree...
#8 118.5 Reading state information...
#8 118.5 Package python3-distutils is not available, but is referred to by another package.
#8 118.5 This may mean that the package is missing, has been obsoleted, or
#8 118.5 is only available from another source
#8 118.5 
#8 118.5 E: Package 'python3-distutils' has no installation candidate
#8 ERROR: process "/bin/sh -c /opt/loci/scripts/install.sh" did not complete successfully: exit code: 100
------
 > [4/4] RUN /opt/loci/scripts/install.sh:
#8 116.3 Reading state information...
#8 116.4 Calculating upgrade...
#8 116.8 0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.

#8 118.5 Reading state information...
#8 118.5 Package python3-distutils is not available, but is referred to by another package.
#8 118.5 This may mean that the package is missing, has been obsoleted, or
#8 118.5 is only available from another source
#8 118.5 
#8 118.5 E: Package 'python3-distutils' has no installation candidate
------
Dockerfile:40
--------------------
  38 |     ADD bindep.txt pydep.txt $EXTRA_BINDEP $EXTRA_PYDEP /opt/loci/
  39 |     
  40 | >>> RUN /opt/loci/scripts/install.sh
  41 |     
--------------------
error: failed to solve: process "/bin/sh -c /opt/loci/scripts/install.sh" did not complete successfully: exit code: 100
FATA[0120] failed to build: build: exit status 1        
FATA[0120] failed to run task: exit status 1     
```