### PR TITLE
Fix virtualenv for python 3.12

### DIFF
--- a/scripts/setup_pip.sh
+++ b/scripts/setup_pip.sh
@@ -28,8 +28,12 @@ source ${PIPBOOTSTRAP}/bin/activate
 # Install setuptools explicitly required for virtualenv > 20 installation
 pip install --upgrade setuptools
 
-# Upgrade to the latest version of virtualenv
-pip install --upgrade ${PIP_ARGS} virtualenv==20.7.2
+# Upgrade to the latest version of virtualenv (for old python version it has to be 20.7.2)
+if (( $(python --version | grep -Po '[0-9]+\.[0-9]+' | cut -d. -f2) >= 12 )); then
+    pip install --upgrade ${PIP_ARGS} virtualenv
+else
+    pip install --upgrade ${PIP_ARGS} virtualenv==20.7.2
+fi
 
 # Forget the cached locations of python binaries
 hash -r


### PR DESCRIPTION
This commit fixes virtualenv installation for Python 3.12 by removing
the bound version 20.7.2. Without this fix, we got the error:
    AttributeError: module 'pkgutil' has no attribute 'ImpImporter'.

At the same time, we keep this binding for older versions because we have
several components that are still running on Python 3.8.

In the future, when we upgrade all our components to newer Python versions,
we have to backport the fix from upstream:
https://github.com/openstack/loci/commit/639122fc1163521a8a37ce3d2a2d8571218c542e
