### PR TITLE
Revert "Switch spice-html5 git repo"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ARG GID=42424
 
 ARG NOVNC_REPO=https://github.com/novnc/novnc
 ARG NOVNC_REF=v1.0.0
-ARG SPICE_REPO=git://anongit.freedesktop.org/spice/spice-html5
+ARG SPICE_REPO=https://gitlab.freedesktop.org/spice/spice-html5.git
 ARG SPICE_REF=spice-html5-0.1.6
 ARG MKS_REPO=https://github.com/rgerganov/noVNC.git
 ARG MKS_REF=master


### PR DESCRIPTION
anongit does not work since more than a week.

This reverts commit f3bb02a46e15a29a9dbb8a5f53f75f90e42eb044.