### PR TITLE
Backport collect pip info

### DIFF
--- a/playbooks/setup-gate.yaml
+++ b/playbooks/setup-gate.yaml
@@ -49,6 +49,7 @@
             name: registry
             image: registry:2
             state: started
+            restart_policy: "always"
             published_ports:
               - 172.17.0.1:5000:5000
         # Allow all connections from containers to host so the

--- a/scripts/collect_info.sh
+++ b/scripts/collect_info.sh
@@ -6,6 +6,7 @@ INFO_DIR="/etc/image_info"
 mkdir -p $INFO_DIR
 PACKAGES_INFO="${INFO_DIR}/packages.txt"
 PIP_INFO="${INFO_DIR}/pip.txt"
+PROJECT_INFO="${INFO_DIR}/project.txt"
 
 case ${distro} in
     debian|ubuntu)
@@ -18,3 +19,13 @@ case ${distro} in
 esac
 
 pip freeze > $PIP_INFO
+cat > ${PROJECT_INFO} <<EOF
+PROJECT=${PROJECT}
+PROJECT_REPO=${PROJECT_REPO}
+PROJECT_REF=${PROJECT_REF}
+PROJECT_RELEASE=${PROJECT_RELEASE}
+EOF
+pushd /tmp/${PROJECT}
+echo "========"
+git log -1 >> ${PROJECT_INFO}
+popd

--- a/scripts/collect_info.sh
+++ b/scripts/collect_info.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -ex
+
+INFO_DIR="/etc/image_info"
+mkdir -p $INFO_DIR
+PACKAGES_INFO="${INFO_DIR}/packages.txt"
+PIP_INFO="${INFO_DIR}/pip.txt"
+
+case ${distro} in
+    debian|ubuntu)
+        dpkg -l > $PACKAGES_INFO
+        ;;
+    *)
+        echo "Unknown distro: ${distro}"
+        exit 1
+        ;;
+esac
+
+pip freeze > $PIP_INFO

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -119,4 +119,5 @@ else
     fi
 fi
 
+$(dirname $0)/collect_info.sh
 $(dirname $0)/cleanup.sh


### PR DESCRIPTION
Backported two commits to collect version info from system packages and python packages so we can diff them in our ci to see what's actually changed.